### PR TITLE
Astrotrac 360 Driver Motion Control Issue

### DIFF
--- a/drivers/telescope/astrotrac.cpp
+++ b/drivers/telescope/astrotrac.cpp
@@ -860,7 +860,8 @@ bool AstroTrac::MoveNS(INDI_DIR_NS dir, TelescopeMotionCommand command)
     }
     else
     {
-        setVelocity(AXIS_DE, TrackRateN[AXIS_DE].value);
+        // reset tracking
+        SetTrackEnabled(TrackState == SCOPE_TRACKING);
         stopMotion(AXIS_DE);
     }
 
@@ -886,7 +887,8 @@ bool AstroTrac::MoveWE(INDI_DIR_WE dir, TelescopeMotionCommand command)
     }
     else
     {
-        setVelocity(AXIS_RA, TrackRateN[AXIS_RA].value);
+        // reset tracking
+        SetTrackEnabled(TrackState == SCOPE_TRACKING);
         stopMotion(AXIS_RA);
     }
 


### PR DESCRIPTION
Moving the mount N/S or E/W via the motion buttons in the indi "Motion Control" tab can inadvertently change the tracking state, even if the scope is idle, because the MoveNS and MoveWE functions always apply the custom tracking rates, which are set to sidereal by default, when motion is stopped. Fixed this issue by calling SetTrackEnabled when motion is stopped to reset tracking. Tested with my Astrotrac 360 mount.