### PR TITLE
Astrotrac 360 Pier Side Property reporting

### DIFF
--- a/drivers/telescope/astrotrac.cpp
+++ b/drivers/telescope/astrotrac.cpp
@@ -679,9 +679,12 @@ bool AstroTrac::ReadScopeStatus()
 
     if (TransformTelescopeToCelestial(TDV, skyRA, skyDE))
     {
+        // set the pier side property, which also conforms to the ASCOM standard as defined by:
+        // https://ascom-standards.org/Help/Developer/html/P_ASCOM_DeviceInterface_ITelescopeV3_SideOfPier.htm
+        // https://download.ascom-standards.org/docs/SideOfPier(1.2).pdf
         double lst = get_local_sidereal_time(LocationN[LOCATION_LONGITUDE].value);
         double dHA = rangeHA(lst - skyRA);
-        setPierSide(dHA < 0 ? PIER_EAST : PIER_WEST);
+        setPierSide(dHA < 0 ? PIER_WEST : PIER_EAST);
 
         char mountRAString[32] = {0}, mountDEString[32] = {0}, skyRAString[32] = {0}, skyDEString[32] = {0};
         fs_sexa(mountRAString, ra, 2, 3600);


### PR DESCRIPTION
The typical park position for the AT360 is with the telescope pointing at the celestial pole and the counter weight shaft pointing vertically down to the ground. In this configuration, the "normal" pointing state (east, pointing west) when the telescope is pointing abve the pole is incorrectly  mapped to "West, pointing East" while the "through the pole" state (west, pointing east) is incorrectly mapped to "East, pointing west". The new mapping reports the "normal" pointing states defined for the TELESCOPE_PIER_SIDE property correctly, which also conforms to the ASCOM standard described at:

https://download.ascom-standards.org/docs/SideOfPier(1.2).pdf https://ascom-standards.org/Help/Developer/html/
P_ASCOM_DeviceInterface_ITelescopeV3_SideOfPier.htm

Note that the old and new pier-side property mappings reflect the telescope pointing state not the physical side-of-pier location.