### PR TITLE
Astrotrac 360 On Coord Set Slew

### DIFF
--- a/drivers/telescope/astrotrac.cpp
+++ b/drivers/telescope/astrotrac.cpp
@@ -660,9 +660,20 @@ bool AstroTrac::ReadScopeStatus()
         {
             if (TrackState == SCOPE_SLEWING)
             {
-                LOG_INFO("Slew complete, tracking...");
-                TrackState = SCOPE_TRACKING;
-                SetTrackEnabled(true);
+                ISwitch *sw;
+                sw = IUFindSwitch(&CoordSP, "TRACK");
+                if ((sw != nullptr) && (sw->s == ISS_ON))
+                {
+                    LOG_INFO("Slew complete, tracking...");
+                    TrackState = SCOPE_TRACKING;
+                    SetTrackEnabled(true);
+                }
+                else
+                {
+                    LOG_INFO("Slew complete, idle");
+                    TrackState = SCOPE_IDLE;
+                    SetTrackEnabled(false);
+                }
             }
             // Parking
             else


### PR DESCRIPTION
When the ON_COORD_SET property is set to "Slew" in the main control tab, the mount currently slews to the target coordinate and automatically starts tracking (as defined for the behviour of "Track"). With the new behaviour, the mount slews to the target coordinate and stops acccording to the definition of "Slew" described at https://www.indilib.org/ developers/deveioper-manual/101-standard-properties.html#h3- telescopes. Tested on the AT360 mount.